### PR TITLE
Update README for 3.2.3 and remove undesired BOM characters

### DIFF
--- a/GodotAddinVS.sln
+++ b/GodotAddinVS.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29806.167

--- a/GodotAddinVS.sln.DotSettings
+++ b/GodotAddinVS.sln.DotSettings
@@ -1,4 +1,4 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=aggregatable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=clsid/@EntryIndexedValue">True</s:Boolean>

--- a/GodotAddinVS/Debugging/GodotDebuggableProjectCfg.cs
+++ b/GodotAddinVS/Debugging/GodotDebuggableProjectCfg.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 using Mono.Debugging.Soft;

--- a/GodotAddinVS/Debugging/GodotDebuggerSession.cs
+++ b/GodotAddinVS/Debugging/GodotDebuggerSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/GodotAddinVS/Debugging/GodotStartInfo.cs
+++ b/GodotAddinVS/Debugging/GodotStartInfo.cs
@@ -1,4 +1,4 @@
-﻿using EnvDTE;
+using EnvDTE;
 using Mono.Debugging.Soft;
 using Mono.Debugging.VisualStudio;
 

--- a/GodotAddinVS/GodotFlavoredProject.cs
+++ b/GodotAddinVS/GodotFlavoredProject.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;

--- a/GodotAddinVS/GodotFlavoredProjectFactory.cs
+++ b/GodotAddinVS/GodotFlavoredProjectFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.Shell.Flavor;
+using Microsoft.VisualStudio.Shell.Flavor;
 using System;
 using System.Runtime.InteropServices;
 

--- a/GodotAddinVS/GodotPackage.cs
+++ b/GodotAddinVS/GodotPackage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/GodotAddinVS/GodotPackage.vsct
+++ b/GodotAddinVS/GodotPackage.vsct
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <CommandTable language="en-us" xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable">
   <Commands package="guidDebugTargetHandlerCmdSet">
     <Buttons>

--- a/GodotAddinVS/GodotSolutionEventsListener.cs
+++ b/GodotAddinVS/GodotSolutionEventsListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;

--- a/GodotAddinVS/NuGet.Config
+++ b/GodotAddinVS/NuGet.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/GodotAddinVS/Properties/AssemblyInfo.cs
+++ b/GodotAddinVS/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/GodotAddinVS/SolutionEventsListener.cs
+++ b/GodotAddinVS/SolutionEventsListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/GodotCompletionProviders.Test/NodePathTests.cs
+++ b/GodotCompletionProviders.Test/NodePathTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace GodotCompletionProviders.Test

--- a/GodotCompletionProviders.Test/Properties/AssemblyInfo.cs
+++ b/GodotCompletionProviders.Test/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GodotCompletionProviders.Test")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/GodotCompletionProviders.Test/ResourcePathTests.cs
+++ b/GodotCompletionProviders.Test/ResourcePathTests.cs
@@ -14,7 +14,7 @@ namespace Godot
         public static Resource Load(string path) => throw new NotImplementedException();
         public static T Load<T>(string path) where T : class => throw new NotImplementedException();
     }
-    
+
     public static class ResourceLoader
     {
         public static Resource Load(string path, string typeHint = "", bool noCache = false) => throw new NotImplementedException();

--- a/GodotCompletionProviders.Test/packages.config
+++ b/GodotCompletionProviders.Test/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.9.4" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="3.3.1" targetFramework="net472" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Visual Studio extension for the Godot game engine C# projects.
 
 ## Requirements
 
-- **Godot 3.2.2** or greater. Older versions of Godot are not supported.
+- **Godot 3.2.3** or greater. Older versions of Godot are not supported and do not work.
 
 ## Features
 


### PR DESCRIPTION
The README was incorrect as per [this blog post](https://godotengine.org/article/csharp-vs-and-vscode), so I fixed it. I also tweaked the wording to make it more clear that it will not work.

Also, I removed BOM characters and trailing spaces, since they are undesired.

I can do a follow-up PR adding the formatting script to GitHub Actions like in the demo projects repository. The formatting script I used also added EOL at EOF to `GodotAddinVS.sln.DotSettings` and `GodotCompletionProviders.Test/packages.config`, but I did not commit these since I wasn't sure if they are desired or not. @neikeq Let me know if they are desired. and I can add them in the follow-up PR.

Also, I would adjust the coloring of the "enhancement" label and other labels to match the coloring used in the other Godot repositories but I don't have edit access for the labels.