### PR TITLE
Allow dependabot to check GitHub actions daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
For consistency sake, some of the other projects under the godotengine have allowed dependabot to check GitHub actions to submit automatic PRs with version bumps. This PR allows dependabot to do the same for this repo in hope to keep all GitHub actions across each project for the godotengine on the same version.