### PR TITLE
Allow use of Visual Studio command line arguments

### DIFF
--- a/GodotAddinVS/Debugging/GodotDebuggableProjectCfg.cs
+++ b/GodotAddinVS/Debugging/GodotDebuggableProjectCfg.cs
@@ -6,6 +6,7 @@ using Mono.Debugging.VisualStudio;
 using System;
 using System.Net;
 using System.Runtime.InteropServices;
+using VSLangProj;
 
 namespace GodotAddinVS.Debugging
 {
@@ -103,6 +104,13 @@ namespace GodotAddinVS.Debugging
             var startArgs = new SoftDebuggerListenArgs(_baseProject.Name, IPAddress.Loopback, port) {MaxConnectionAttempts = 3};
 
             var startInfo = new GodotStartInfo(startArgs, null, _baseProject) {WorkingDirectory = GodotPackage.Instance.GodotSolutionEventsListener?.SolutionDir};
+            
+            try 
+            {
+                if (_baseProject.ConfigurationManager.ActiveConfiguration.Object is ProjectConfigurationProperties props)
+                    startInfo.StartArguments = props.StartArguments;
+            } catch(Exception){}
+            
             var session = new GodotDebuggerSession();
 
             var launcher = new MonoDebuggerLauncher(new Progress<string>());

--- a/GodotAddinVS/Debugging/GodotDebuggerSession.cs
+++ b/GodotAddinVS/Debugging/GodotDebuggerSession.cs
@@ -136,7 +136,7 @@ namespace GodotAddinVS.Debugging
 
                     var processStartInfo = new ProcessStartInfo(GetGodotExecutablePath())
                     {
-                        Arguments = $"--path {workingDir} --remote-debug {host}:{remoteDebugPort}", // TODO: Doesn't work with 4.0dev. Should be tcp://host:port which doesn't work in 3.2...
+                        Arguments = $"--path {workingDir} --remote-debug {host}:{remoteDebugPort} {godotStartInfo.StartArguments}", // TODO: Doesn't work with 4.0dev. Should be tcp://host:port which doesn't work in 3.2...
                         WorkingDirectory = workingDir,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,

--- a/GodotAddinVS/Debugging/GodotStartInfo.cs
+++ b/GodotAddinVS/Debugging/GodotStartInfo.cs
@@ -6,6 +6,7 @@ namespace GodotAddinVS.Debugging
 {
     internal class GodotStartInfo : StartInfo
     {
+        public string StartArguments;
         public GodotStartInfo(SoftDebuggerStartArgs args, DebuggingOptions options, Project startupProject) :
             base(args, options, startupProject)
         {


### PR DESCRIPTION
Unless I'm missing something I can't use https://docs.godotengine.org/en/stable/tutorials/editor/command_line_tutorial.html directly from Visual Studio? 