### PR TITLE
Add detection of sdk style projects

### DIFF
--- a/GodotAddinVS/GodotPackage.cs
+++ b/GodotAddinVS/GodotPackage.cs
@@ -36,6 +36,7 @@ namespace GodotAddinVS
     [ProvideOptionPage(typeof(GeneralOptionsPage),
         "Godot", "General", 0, 0, true)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
+    [ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]
     public sealed class GodotPackage : AsyncPackage
     {
         /// <summary>


### PR DESCRIPTION
This PR adds detection of sdk style projets inside the IsGodotProject() method.

To make this work I had to add "[ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]" to the GodotPackage class to initialize the extension right on startup.
Otherwise OnAfterOpenProject() wont get called.

This PR can be built upon to hopefully make GodotTools.IdeMessaging.Client work with Godot 4